### PR TITLE
Support *.rules

### DIFF
--- a/ftdetect/firestore.vim
+++ b/ftdetect/firestore.vim
@@ -1,1 +1,1 @@
-autocmd BufNewFile,BufRead firestore.rules set filetype=firestore
+autocmd BufNewFile,BufRead *.rules set filetype=firestore


### PR DESCRIPTION
In addition to `firestore.rules`, this syntax also applies to `storage.rules` and will possibly support others in the future.