### PR TITLE
(Feature) Add support for Firebase Storage rules

### DIFF
--- a/syntax/firestore.vim
+++ b/syntax/firestore.vim
@@ -25,6 +25,9 @@ hi def link firestoreService Statement
 syntax match firestoreCloudFirestore +cloud\.firestore+ nextgroup=firestoreDeclaration skipwhite skipnl
 hi def link firestoreCloudFirestore Keyword
 
+syntax match firebaseStorage +firebase\.storage+ nextgroup=firestoreDeclaration skipwhite skipnl
+hi def link firebaseStorage Keyword
+
 syn region firestoreDeclaration matchgroup=firestoreBraces start=/{/ end=/}\_s*\%$/ contains=firestoreFunction,firestoreMatch,firestoreComment,@firestoreSyntaxError
 " }}}
 


### PR DESCRIPTION
Hello. Thank you very much for your plugin.
I do not use deoplete, but I think the syntax highlight is very nice!

I noted that the syntax matchers are specific for the Firestore rules. I would like to add support for the Firebase Storage as well, as they have (AFAIK) the same syntax.

I started by adding a matcher for the service `firebase.storage`. Adding this already gives me the same highlights for `storage.rules` as the `firestore.rules` rules file has.

Do you have any interest in expanding the support for the `storage.rules` file?

Reference: https://firebase.google.com/docs/storage/security/core-syntax