### PR TITLE
fix: Highlight comment in parentheses correctly

### DIFF
--- a/syntax/firestore.vim
+++ b/syntax/firestore.vim
@@ -97,7 +97,7 @@ syn cluster firestoreExpression contains=@firestoreValue,firestoreParentheses,fi
 
 syn cluster firestoreNextStatement contains=firestoreMethod,firestoreProperty,@firestoreOp,@firestoreMatchBlockStatement
 
-syn region firestoreParentheses matchgroup=firestoreParens start=/(/ end=/)/ nextgroup=@firestoreNextStatement,firestoreSlice skipwhite skipnl contains=@firestoreExpression
+syn region firestoreParentheses matchgroup=firestoreParens start=/(/ end=/)/ nextgroup=@firestoreNextStatement,firestoreSlice skipwhite skipnl contains=@firestoreExpression,firestoreComment
 
 " Value {{{
 syn cluster firestoreValue contains=firestoreVariable,firestoreFunctionCall,@firestoreNumber,@firestorePath,firestoreString,firestoreList,firestoreMap,firestoreValueKeywords


### PR DESCRIPTION
Hi, thank you for the nice plugin.
It seems that the current syntax highlight does not handle a comment in parentheses correctly, so I fixed it.


### Before

<img width="265" alt="Terminal_—_tmux_—_283×76-2" src="https://user-images.githubusercontent.com/12684251/219820128-8b30a202-5a34-4056-9f88-8ca2515bd0ab.png">


### After

<img width="256" alt="Terminal_—_tmux_—_283×76-3" src="https://user-images.githubusercontent.com/12684251/219820136-9b6cf4af-9080-411e-ac70-0332bf1cf077.png">

