### PR TITLE
feat: detect ternary operator additionally

### DIFF
--- a/sample-firestore.rules
+++ b/sample-firestore.rules
@@ -16,6 +16,13 @@ service cloud.firestore {
       return request.resource.data
     }
 
+    function isGroupMember(group, visibility) {
+      let membership = visibility == "adminsOnly"
+        ? /databases/$(db)/documents/admins/$(request.auth.uid)
+        : /databases/$(db)/documents/$(group)/$(request.auth.uid);
+      return exists(membership);
+    }
+
     // nested match statement
     match /users/{document=**} {
       // semicolon also available

--- a/syntax/firestore.vim
+++ b/syntax/firestore.vim
@@ -192,7 +192,7 @@ syn keyword firestoreOpKeywords is nextgroup=firestoreType skipwhite skipnl cont
 syn keyword firestoreOpKeywords in nextgroup=@firestoreExpression skipwhite skipnl containedin=@firestoreOp
 hi def link firestoreOpKeywords Operator
 
-syn match firestoreOpArithmetics ,[-+*%:]\|!!\|&&\|||\|[!=]==\?\|>=\|<=\|<<[<=]\?\|>>[>=]?\|[=!><|&], nextgroup=@firestoreExpression skipwhite skipnl containedin=@firestoreOp
+syn match firestoreOpArithmetics ,[-+*%?:]\|!!\|&&\|||\|[!=]==\?\|>=\|<=\|<<[<=]\?\|>>[>=]?\|[=!><|&], nextgroup=@firestoreExpression skipwhite skipnl containedin=@firestoreOp
 hi def link firestoreOpArithmetics Operator
 
 syn match firestoreOpSlash +/+ nextgroup=@firestoreExpression skipwhite skipnl contained


### PR DESCRIPTION
Fix #18

| before | after |
|--|--|
| <img width="512" alt="スクリーンショット 0005-08-06 9 48 27" src="https://github.com/delphinus/vim-firestore/assets/1239245/4323652b-2354-4fdb-b2fd-f319f796ca8d"> | <img width="510" alt="スクリーンショット 0005-08-06 9 57 08" src="https://github.com/delphinus/vim-firestore/assets/1239245/aeb0c30b-2e47-480a-98ef-ffe82396d2ba"> |
